### PR TITLE
dyn.log 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Depends:
-    R (>= 4.1)
+    R (>= 4.0)
 Imports:
     crayon (>= 1.4.1),
     glue (>= 1.4.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,10 +21,10 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Depends:
-    R (>= 4.0)
+    R (>= 4.1)
 Imports:
     crayon (>= 1.4.1),
-    glue (>= 1.6.1),
+    glue (>= 1.4.2),
     R6 (>= 2.5.1),
     rlang (>= 0.4.12),
     stringr (>= 1.4.0),
@@ -35,21 +35,21 @@ URL: https://bmoretz.github.io/dyn.log/
 BugReports: https://github.com/bmoretz/dyn.log/issues
 RoxygenNote: 7.1.2
 Suggests: 
-    devtools (>= 2.4.3),
-    usethis (>= 2.1.5),
-    rmarkdown (>= 2.11),
-    knitr (>= 1.37),
+    devtools,
+    usethis,
+    rmarkdown,
+    knitr,
     covr (>= 3.5.1),
     testthat (>= 3.0.0),
     lintr (>= 0.28),
-    remotes (>= 2.4.2),
-    pkgdown (> 2.0.2),
-    prettydoc (>= 0.4.1),
-    here (>= 1.0.1),
-    fansi (>= 1.0.2),
-    DT (>= 0.20),
-    languageserver (>= 0.3.12),
-    httpgd (>= 1.2.1)
+    remotes,
+    pkgdown,
+    prettydoc,
+    here,
+    fansi,
+    DT,
+    languageserver,
+    httpgd
 Config/testthat/edition: 3
 Language: en-US
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # dyn.log
 
-# Hex <img src="man/figures/hex.png" width = "175" height = "200" align="right" />
+# Overview <img src="man/figures/hex.png" width = "175" height = "200" align="right" />
 
 <!-- badges: start -->
 

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -7,11 +7,6 @@ local({
   # the project directory
   project <- getwd()
 
-  # figure out path to 'renv' folder from this script
-  call <- sys.call(1L)
-  if (is.call(call) && identical(call[[1L]], as.symbol("source")))
-    Sys.setenv(RENV_PATHS_RENV = dirname(call[[2L]]))
-
   # figure out whether the autoloader is enabled
   enabled <- local({
 


### PR DESCRIPTION
## What's Changed

* New Features
  + Added private field support for class context logging.
  
* Enhancements
  + added lintr coverage to makefile.
  + added public & private property examples to the Configuration vignette.
  + bug fix in call stack context due to change in rlang::trace
  + cleaned up formatting for all unit tests.
  
* lintr code clean-up, cleaned up all lintr warnings in the following categories:
  + object_name_lintr (R6 Class names have explicit excludes)
  + commas_lintr
  + assignment_lintr
  + object_useage_lintr
  + spaces_left_parenthesis_linter